### PR TITLE
Fix energy measurement that is not in microjoules

### DIFF
--- a/pyJoules/device/nvidia_device.py
+++ b/pyJoules/device/nvidia_device.py
@@ -76,7 +76,7 @@ class NvidiaGPUDevice(Device):
         self._handle = [pynvml.nvmlDeviceGetHandleByIndex(domain.device_id) for domain in self._configured_domains]
 
     def get_energy(self):
-        return [pynvml.nvmlDeviceGetTotalEnergyConsumption(handle) for handle in self._handle]
+        return [pynvml.nvmlDeviceGetTotalEnergyConsumption(handle) * 1000 for handle in self._handle]
 
     @staticmethod
     def available_domains() -> List[NvidiaGPUDomain]:


### PR DESCRIPTION
The function nvmlDeviceGetTotalEnergyConsumption returns the energy consumption in millijoules, not microjoules. In order for it to have the same units as the other energy measurements, the returned value should be multiplied by 1000.

More info in [NVML's documentation](https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html).