### PR TITLE
fix: handle overflow correction errors gracefully (fixes #18)

### DIFF
--- a/pyJoules/energy_meter.py
+++ b/pyJoules/energy_meter.py
@@ -266,10 +266,17 @@ class EnergyState:
         values_dict = {}
         for value, key in zip(energy, domains):
             if value < 0:
-                device = key.get_device_type()
-                domain_dirname = device._get_domain_file_name(None, key)[:-9]
-                with open(domain_dirname + 'max_energy_range_uj', 'r') as file:
-                    value += float(file.readline())
+                # Handle RAPL counter overflow by adding max_energy_range_uj
+                try:
+                    device = key.get_device_type()
+                    domain_dirname = device._get_domain_file_name(None, key)[:-9]
+                    with open(domain_dirname + 'max_energy_range_uj', 'r') as file:
+                        value += float(file.readline())
+                except (AttributeError, FileNotFoundError, ValueError):
+                    # Device doesn't support overflow correction (e.g., NVIDIA GPU)
+                    # or max_energy_range_uj file not found - keep negative value
+                    # Users can filter these with EnergyTrace.clean_data()
+                    pass
             values_dict[str(key)] = value
         return values_dict
 


### PR DESCRIPTION
Add try-except around RAPL overflow correction to handle:
- NVIDIA GPU devices that don't have _get_domain_file_name method
- Missing max_energy_range_uj files
- Invalid file paths

When overflow correction fails, the negative value is preserved. Users can filter these with EnergyTrace.clean_data() method.