### PR TITLE
fix: correct spelling errors in energy_meter and energy_trace

### DIFF
--- a/pyJoules/energy_meter.py
+++ b/pyJoules/energy_meter.py
@@ -87,7 +87,7 @@ class EnergyMeter:
     def _is_meter_started(self):
         return not self._first_state is None
 
-    def _is_meter_stoped(self):
+    def _is_meter_stopped(self):
         return self._last_state.tag == '__stop__'
 
     def _reinit(self):
@@ -127,7 +127,7 @@ class EnergyMeter:
         if not self._is_meter_started():
             return self.start(tag)
         
-        if not self._is_meter_stoped():
+        if not self._is_meter_stopped():
             raise EnergyMeterNotStoppedError()
 
         new_state = self._measure_new_state(tag)
@@ -154,7 +154,7 @@ class EnergyMeter:
         if not self._is_meter_started():
             return EnergyTrace([])
 
-        if not self._is_meter_stoped():
+        if not self._is_meter_stopped():
             raise EnergyMeterNotStoppedError()
 
         return self._generate_trace()
@@ -222,7 +222,7 @@ class EnergyState:
 
     def __init__(self, timestamp: float, tag: str, values: List[Dict[str, float]]):
         """
-        :param timstamp: timestamp of the measure
+        :param timestamp: timestamp of the measure
         :param tag: tag of the measure
         :param values: energy consumption measure, this is the list of measured energy consumption values for each
                        monitored device. This list contains the energy consumption since the last device reset to the

--- a/pyJoules/energy_trace.py
+++ b/pyJoules/energy_trace.py
@@ -115,7 +115,7 @@ class EnergyTrace:
                            or if a domain of the trace is not in the idle values
         """
         if len(idle) != len(self._samples):
-            raise ValueError('idle list havn\'t the same length than the trace')
+            raise ValueError('idle list hasn\'t the same length as the trace')
 
         for idle_energy, sample in zip(idle, self._samples):
             for domain in sample.energy:
@@ -123,7 +123,7 @@ class EnergyTrace:
                     raise ValueError('domain not present in idle values : ' + domain)
                 sample.energy[domain] -= idle_energy[domain]
 
-    def _sample_havnt_negative_values(self, sample):
+    def _sample_hasnt_negative_values(self, sample):
         for val in sample.energy.values():
             if val < 0:
                 return False
@@ -138,7 +138,7 @@ class EnergyTrace:
                        sample as parameter and return True if it must be keept in the trace, False otherwise
         """
 
-        extended_guards = [lambda s: self._sample_havnt_negative_values(s)] + guards
+        extended_guards = [lambda s: self._sample_hasnt_negative_values(s)] + guards
 
         valid_samples = []
         for sample in self._samples:

--- a/tests/unit/energy_meter/test_EnergyMeter.py
+++ b/tests/unit/energy_meter/test_EnergyMeter.py
@@ -113,7 +113,7 @@ def test_stop_a_non_started_energy_meter_raise_EnergyMeterNotStartedError(energy
         energy_meter.stop()
 
 
-def test_resume_a_non_stoped_energy_meter_raise_EnergyMeterNotStoppedError(energy_meter):
+def test_resume_a_non_stopped_energy_meter_raise_EnergyMeterNotStoppedError(energy_meter):
     with pytest.raises(EnergyMeterNotStoppedError):
         energy_meter.start()
         energy_meter.resume()


### PR DESCRIPTION
## Summary
- Rename `_is_meter_stoped` to `_is_meter_stopped`
- Fix 'timstamp' typo in docstring to 'timestamp'
- Fix 'havn't' to 'hasn't' in error message
- Rename `_sample_havnt_negative_values` to `_sample_hasnt_negative_values`
- Fix test name to use 'stopped' instead of 'stoped'

## Test plan
- [x] All existing tests pass